### PR TITLE
Fix allowing return value from WASM

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ wasm-bindgen-test = "0.3.34"
 wasm-bindgen-futures = "0.4.34"
 wasm-bindgen = "0.2.84"
 oneshot = "0.1.5"
-axum = { version = "0.6.19", default-features = false }
+axum = { version = "0.6.19", default-features = false, features = ["macros"] }
 tower-service = "0.3.2"
 
 reqwest = { version = "0.11.18", default-features = false, features = ["rustls-tls"] }


### PR DESCRIPTION
Prior to this PR, it wasn't possible to use the try operator (`?`), or return a value in the WASM-variant of the function. For the non-WASM, this worked as expected. This required for the WASM-builds using `unwrap()` for everything, rather than proper error handling with error types that `impl IntoResponse`. 👍🏻 

@logankeenan 